### PR TITLE
1. asynchronous calls to raygun, having captured stack traces previou…

### DIFF
--- a/raygun4go.go
+++ b/raygun4go.go
@@ -182,6 +182,22 @@ func (c *Client) CreateError(message string) error {
 	return c.submit(post)
 }
 
+//Post holds postData (including a stack). This allows for asynchronous reporting to raygun (without losing the stack trace)
+type Post struct {
+	postData postData
+}
+
+//CreatePost is a wrapper to manually post errors to raygun. It also allows to specify the index for stack trace truncation.
+func (c *Client) CreatePost(err error, stackTruncateAt int) Post {
+	post := c.createPost(err, currentStackAt(stackTruncateAt))
+	return Post{postData: post}
+}
+
+//SubmitPost is a wrapper to manually post errors to raygun asynchronously (having previously captured a stack trace on a separate goroutine, using c.CreatePost())
+func (c *Client) SubmitPost(post Post) error {
+	return c.submit(post.postData)
+}
+
 // submit takes care of actually sending the error to Raygun unless the silent
 // option is set.
 func (c *Client) submit(post postData) error {

--- a/request_data.go
+++ b/request_data.go
@@ -74,12 +74,16 @@ func newErrorData(err error, s stackTrace) errorData {
 	}
 }
 
-// currentStac returns the current stack. However, it omits the first 3 entries
+// currentStack returns the current stack. However, it omits the first 4 entries
 // to avoid cluttering the trace with raygun4go-specific calls.
 func currentStack() stackTrace {
+	return currentStackAt(4)
+}
+
+func currentStackAt(index int) stackTrace {
 	s := make(stackTrace, 0, 0)
 	stack2struct.Current(&s)
-	return s[3:]
+	return s[index:]
 }
 
 // stackTraceElement is one element of the error's stack trace. It is filled by


### PR DESCRIPTION
…sly. 2. control over stack trace truncation
